### PR TITLE
Add bottom navigation bar with Provider state management

### DIFF
--- a/lib/core/view_model/bottom_navbar_vm.dart
+++ b/lib/core/view_model/bottom_navbar_vm.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class BottomNavbarVm extends ChangeNotifier{
+  int currentIndex = 0;
+
+  void updateIndex(int newIndex) {
+    currentIndex = newIndex;
+    notifyListeners();
+  }
+  
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:travel_hub/core/view_model/bottom_navbar_vm.dart';
 import 'package:travel_hub/presentation/view/onboarding_screen.dart';
 
 void main() {
@@ -10,10 +12,15 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'Travel App',
-      home: OnboardingScreen(),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => BottomNavbarVm()),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: 'Travel App',
+        home: OnboardingScreen(),
+      ),
     );
   }
 }

--- a/lib/presentation/view/bottom_navbar.dart
+++ b/lib/presentation/view/bottom_navbar.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:travel_hub/core/view_model/bottom_navbar_vm.dart';
 
 class BottomNavbar extends StatefulWidget {
   const BottomNavbar({super.key});
@@ -8,8 +10,62 @@ class BottomNavbar extends StatefulWidget {
 }
 
 class _BottomNavbarState extends State<BottomNavbar> {
+  final List<Widget> _screens = const [
+    Center(child: Text("Home Screen")),
+    Center(child: Text("Tickets Screen")),
+    Center(child: Text("Favorites Screen")),
+    Center(child: Text("Profile Screen")),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    final bottomVm = Provider.of<BottomNavbarVm>(context);
+    return Scaffold(
+      backgroundColor: Colors.grey[100],
+      body: _screens[bottomVm.currentIndex],
+      bottomNavigationBar: Container(
+        margin: const EdgeInsets.all(10),
+        height: 70,
+        decoration: BoxDecoration(
+          color: Color(0xffFFFFFF),
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(30),
+            topRight: Radius.circular(30),
+            bottomLeft: Radius.circular(30),
+            bottomRight: Radius.circular(30),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withAlpha(25),
+              blurRadius: 10,
+              offset: const Offset(0, 5),
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: List.generate(4, (index) {
+            final bool isSelected = bottomVm.currentIndex == index;
+
+            final List<IconData> icons = [
+              Icons.home_rounded,
+              Icons.confirmation_num_rounded,
+              Icons.favorite_rounded,
+              Icons.person_rounded,
+            ];
+            return GestureDetector(
+              onTap: () {
+                bottomVm.updateIndex(index);
+              },
+              child: Icon(
+                icons[index],
+                size: 26,
+                color: isSelected ? Colors.blue : Colors.grey,
+              ),
+            );
+          }),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/view/onboarding_screen.dart
+++ b/lib/presentation/view/onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:travel_hub/presentation/view/bottom_navbar.dart';
 
 class OnboardingScreen extends StatelessWidget {
   const OnboardingScreen({super.key});
@@ -71,7 +72,9 @@ class OnboardingScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(20),
                 ),
               ),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) => BottomNavbar()));
+              },
               child: Text(
                 'Explore',
                 style: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -139,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.1.5+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Introduced BottomNavbarVm using Provider for managing bottom navigation state. Updated main.dart to use MultiProvider, implemented a custom BottomNavbar widget with navigation logic, and connected onboarding screen to navigate to the bottom navbar. Added provider dependency to pubspec.yaml.